### PR TITLE
Fix compile errors and support REM GENRE lines

### DIFF
--- a/cue_parser.y
+++ b/cue_parser.y
@@ -121,6 +121,7 @@ Cd *cue_parse_string(const char*);
 /* REM */
 %type <ival> rem_item
 %token <ival> DATE
+%token <ival> XXX_GENRE /* parsed in REM but stored in CD-TEXT */
 %token <ival> REPLAYGAIN_ALBUM_GAIN
 %token <ival> REPLAYGAIN_ALBUM_PEAK
 %token <ival> REPLAYGAIN_TRACK_GAIN
@@ -301,6 +302,7 @@ time
 
 rem
 	: rem_item STRING '\n' { rem_set($1, $2, rem); }
+	| XXX_GENRE STRING '\n' { cdtext_set($1, $2, cdtext); }
 	;
 
 rem_item

--- a/cue_scanner.l
+++ b/cue_scanner.l
@@ -99,6 +99,7 @@ ISRC		{ BEGIN(NAME); return TRACK_ISRC; }
 REM		{ BEGIN(REM); /* exclusive rules for special exceptions */ }
 
 <REM>DATE			{ BEGIN(NAME); yylval.ival = REM_DATE; return DATE; }
+<REM>GENRE			{ BEGIN(NAME); yylval.ival = PTI_GENRE; return XXX_GENRE; }
 <REM>REPLAYGAIN_ALBUM_GAIN 	{ BEGIN(RPG); yylval.ival = REM_REPLAYGAIN_ALBUM_GAIN;
 							return REPLAYGAIN_ALBUM_GAIN; }
 <REM>REPLAYGAIN_ALBUM_PEAK	{ BEGIN(RPG); yylval.ival = REM_REPLAYGAIN_ALBUM_PEAK;

--- a/libcue.h
+++ b/libcue.h
@@ -6,55 +6,13 @@
 #ifndef LIBCUE_H
 #define LIBCUE_H
 
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define CUE_EXPORT __attribute__((visibility("default")))
-
-/* ADTs */
-typedef struct Cd Cd;
-typedef struct Track Track;
-typedef struct Cdtext Cdtext;
-typedef struct Rem Rem;
-typedef enum Pti Pti;
-typedef enum TrackFlag TrackFlag;
-typedef enum RemType RemType;
-
-CUE_EXPORT Cd* cue_parse_file(FILE*);
-CUE_EXPORT Cd* cue_parse_string(const char*);
-CUE_EXPORT void cd_delete(Cd* cd);
-
-/* CD functions */
-CUE_EXPORT enum DiscMode cd_get_mode(const Cd *cd);
-CUE_EXPORT const char *cd_get_cdtextfile(const Cd *cd);
-/*
- * return number of tracks in cd
- */
-CUE_EXPORT int cd_get_ntrack(const Cd *cd);
-
-/* CDTEXT functions */
-CUE_EXPORT Cdtext *cd_get_cdtext(const Cd *cd);
-CUE_EXPORT Cdtext *track_get_cdtext(const Track *track);
-CUE_EXPORT const char *cdtext_get(enum Pti pti, const Cdtext *cdtext);
-
-CUE_EXPORT Rem* cd_get_rem(const Cd* cd);
-CUE_EXPORT Rem* track_get_rem(const Track* track);
-/**
- * return pointer to value for rem comment
- * @param unsigned int: enum of rem comment
- */
-CUE_EXPORT const char* rem_get(unsigned int, Rem*);
-
-/* Track functions */
-CUE_EXPORT Track *cd_get_track(const Cd *cd, int i);
-CUE_EXPORT const char *track_get_filename(const Track *track);
-CUE_EXPORT long track_get_start(const Track *track);
-CUE_EXPORT long track_get_length(const Track *track);
-CUE_EXPORT enum TrackMode track_get_mode(const Track *track);
-CUE_EXPORT enum TrackSubMode track_get_sub_mode(const Track *track);
-CUE_EXPORT int track_is_set_flag(const Track *track, enum TrackFlag flag);
-CUE_EXPORT long track_get_zero_pre(const Track *track);
-CUE_EXPORT long track_get_zero_post(const Track *track);
-CUE_EXPORT const char *track_get_isrc(const Track *track);
-CUE_EXPORT long track_get_index(const Track *track, int i);
-
 
 /*
  * disc modes
@@ -142,5 +100,56 @@ enum RemType {
 	REM_REPLAYGAIN_TRACK_PEAK,
 	REM_END		/* terminating REM (for stepping through REMs) */
 };
+
+/* ADTs */
+typedef struct Cd Cd;
+typedef struct Track Track;
+typedef struct Cdtext Cdtext;
+typedef struct Rem Rem;
+typedef enum Pti Pti;
+typedef enum TrackFlag TrackFlag;
+typedef enum RemType RemType;
+
+CUE_EXPORT Cd* cue_parse_file(FILE*);
+CUE_EXPORT Cd* cue_parse_string(const char*);
+CUE_EXPORT void cd_delete(Cd* cd);
+
+/* CD functions */
+CUE_EXPORT enum DiscMode cd_get_mode(const Cd *cd);
+CUE_EXPORT const char *cd_get_cdtextfile(const Cd *cd);
+/*
+ * return number of tracks in cd
+ */
+CUE_EXPORT int cd_get_ntrack(const Cd *cd);
+
+/* CDTEXT functions */
+CUE_EXPORT Cdtext *cd_get_cdtext(const Cd *cd);
+CUE_EXPORT Cdtext *track_get_cdtext(const Track *track);
+CUE_EXPORT const char *cdtext_get(enum Pti pti, const Cdtext *cdtext);
+
+CUE_EXPORT Rem* cd_get_rem(const Cd* cd);
+CUE_EXPORT Rem* track_get_rem(const Track* track);
+/**
+ * return pointer to value for rem comment
+ * @param unsigned int: enum of rem comment
+ */
+CUE_EXPORT const char* rem_get(unsigned int, Rem*);
+
+/* Track functions */
+CUE_EXPORT Track *cd_get_track(const Cd *cd, int i);
+CUE_EXPORT const char *track_get_filename(const Track *track);
+CUE_EXPORT long track_get_start(const Track *track);
+CUE_EXPORT long track_get_length(const Track *track);
+CUE_EXPORT enum TrackMode track_get_mode(const Track *track);
+CUE_EXPORT enum TrackSubMode track_get_sub_mode(const Track *track);
+CUE_EXPORT int track_is_set_flag(const Track *track, enum TrackFlag flag);
+CUE_EXPORT long track_get_zero_pre(const Track *track);
+CUE_EXPORT long track_get_zero_post(const Track *track);
+CUE_EXPORT const char *track_get_isrc(const Track *track);
+CUE_EXPORT long track_get_index(const Track *track, int i);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/t/standard_cue.c
+++ b/t/standard_cue.c
@@ -46,6 +46,14 @@ static char* cue_test()
    mu_assert ("error getting CD title", val != NULL);
    mu_assert ("error validating CD title", strcmp (val, "Loveless") == 0);
 
+   val = cdtext_get (PTI_GENRE, cdtext);
+   mu_assert ("error getting CD genre", val != NULL);
+   mu_assert ("error validating CD genre", strcmp (val, "Alternative") == 0);
+
+   val = rem_get (REM_DATE, rem);
+   mu_assert ("error getting CD date", val != NULL);
+   mu_assert ("error validating CD date", strcmp (val, "1991") == 0);
+
    int ival = cd_get_ntrack (cd);
    mu_assert ("invalid number of tracks", ival == 2);
 


### PR DESCRIPTION
I'm working on a downstream bug in Audacious:
http://redmine.audacious-media-player.org/issues/608

Along the way I noticed that libcue is not parsing lines starting with REM GENRE, only GENRE without the REM.  The fix is a little ugly because the libcue API puts the genre in the CD-Text data, but all other REM lines in a separate Rem struct.

Also there were many new compile errors when trying to build Audacious with the new libcue.  Most are due to referencing enums before they are defined (C++ allows this only if you use "enum class").  There was also a reference to FILE without including stdio.h.