### PR TITLE
Function renaming because of equally named functions in libcdio.

### DIFF
--- a/cd.c
+++ b/cd.c
@@ -52,7 +52,7 @@ Cd *cd_init(void)
 		cd->mode = MODE_CD_DA;
 		cd->catalog = NULL;
 		cd->cdtextfile = NULL;
-		cd->cdtext = cdtext_init();
+		cd->cdtext = cue_cdtext_init();
 		cd->rem = rem_new();
 		cd->ntrack = 0;
 	}
@@ -64,7 +64,7 @@ void track_delete(struct Track* track)
 {
 	if (track != NULL)
 	{
-		cdtext_delete(track_get_cdtext(track));
+		cue_cdtext_delete(track_get_cdtext(track));
 
 		rem_free(track_get_rem(track));
 
@@ -93,7 +93,7 @@ void cd_delete(struct Cd* cd)
 		for (i = 0; i < cd->ntrack; i++)
 			track_delete(cd->track[i]);
 
-		cdtext_delete(cd_get_cdtext(cd));
+		cue_cdtext_delete(cd_get_cdtext(cd));
 
 		rem_free(cd_get_rem(cd));
 
@@ -128,7 +128,7 @@ Track *track_init(void)
 		track->sub_mode = SUB_MODE_RW;
 		track->flags = FLAG_NONE;
 		track->isrc = NULL;
-		track->cdtext = cdtext_init();
+		track->cdtext = cue_cdtext_init();
 		track->rem = rem_new();
 
                 int i;
@@ -378,7 +378,7 @@ static void cd_track_dump(Track *track)
 
 	if (NULL != track->cdtext) {
 		printf("cdtext:\n");
-		cdtext_dump(track->cdtext, 1);
+		cue_cdtext_dump(track->cdtext, 1);
 	}
 
 	if (track->rem != NULL)
@@ -398,7 +398,7 @@ void cd_dump(Cd *cd)
 	printf("cdtextfile: %s\n", cd->cdtextfile);
 	if (NULL != cd->cdtext) {
 		printf("cdtext:\n");
-		cdtext_dump(cd->cdtext, 0);
+		cue_cdtext_dump(cd->cdtext, 0);
 	}
 
 	if (cd->rem != NULL)

--- a/cdtext.c
+++ b/cdtext.c
@@ -15,7 +15,7 @@ struct Cdtext {
 	char *value;
 };
 
-Cdtext *cdtext_init(void)
+Cdtext *cue_cdtext_init(void)
 {
 	Cdtext *new_cdtext = NULL;
 
@@ -48,7 +48,7 @@ Cdtext *cdtext_init(void)
 	return new_cdtext;
 }
 
-void cdtext_delete(Cdtext *cdtext)
+void cue_cdtext_delete(Cdtext *cdtext)
 {
 	int i;
 
@@ -62,7 +62,7 @@ void cdtext_delete(Cdtext *cdtext)
 }
 
 /* return 0 if there is no cdtext, returns non-zero otherwise */
-int cdtext_is_empty(Cdtext *cdtext)
+int cue_cdtext_is_empty(Cdtext *cdtext)
 {
 	for (; PTI_END != cdtext->pti; cdtext++)
 		if (NULL != cdtext->value)
@@ -72,7 +72,7 @@ int cdtext_is_empty(Cdtext *cdtext)
 }
 
 /* sets cdtext's pti entry to field */
-void cdtext_set(int pti, char *value, Cdtext *cdtext)
+void cue_cdtext_set(int pti, char *value, Cdtext *cdtext)
 {
 	if (NULL != value)	/* don't pass NULL to strdup */
 		for (; PTI_END != cdtext->pti; cdtext++)
@@ -92,7 +92,7 @@ const char *cue_cdtext_get(enum Pti pti, const Cdtext *cdtext)
 	return NULL;
 }
 
-const char *cdtext_get_key(int pti, int istrack)
+const char *cue_cdtext_get_key(int pti, int istrack)
 {
 	const char *key = NULL;
 
@@ -153,14 +153,14 @@ const char *cdtext_get_key(int pti, int istrack)
 	return key;
 }
 
-void cdtext_dump(Cdtext *cdtext, int istrack)
+void cue_cdtext_dump(Cdtext *cdtext, int istrack)
 {
 	int pti;
 	const char *value = NULL;
 
 	for (pti = 0; PTI_END != pti; pti++) {
 		if (NULL != (value = cue_cdtext_get(pti, cdtext))) {
-			printf("%s: ", cdtext_get_key(pti, istrack));
+			printf("%s: ", cue_cdtext_get_key(pti, istrack));
 			printf("%s\n", value);
 		}
 	}

--- a/cdtext.c
+++ b/cdtext.c
@@ -83,7 +83,7 @@ void cdtext_set(int pti, char *value, Cdtext *cdtext)
 }
 
 /* returns value for pti, NULL if pti is not found */
-const char *cdtext_get(enum Pti pti, const Cdtext *cdtext)
+const char *cue_cdtext_get(enum Pti pti, const Cdtext *cdtext)
 {
 	for (; PTI_END != cdtext->pti; cdtext++)
 		if (pti == cdtext->pti)
@@ -159,7 +159,7 @@ void cdtext_dump(Cdtext *cdtext, int istrack)
 	const char *value = NULL;
 
 	for (pti = 0; PTI_END != pti; pti++) {
-		if (NULL != (value = cdtext_get(pti, cdtext))) {
+		if (NULL != (value = cue_cdtext_get(pti, cdtext))) {
 			printf("%s: ", cdtext_get_key(pti, istrack));
 			printf("%s\n", value);
 		}

--- a/cdtext.h
+++ b/cdtext.h
@@ -17,28 +17,28 @@ enum PtiFormat {
 };
 
 /* return a pointer to a new Cdtext */
-Cdtext *cdtext_init(void);
+Cdtext *cue_cdtext_init(void);
 
 /* release a Cdtext */
-void cdtext_delete(Cdtext *cdtext);
+void cue_cdtext_delete(Cdtext *cdtext);
 
 /* returns non-zero if there are no CD-TEXT fields set, zero otherwise */
-int cdtext_is_empty(Cdtext *cdtext);
+int cue_cdtext_is_empty(Cdtext *cdtext);
 
 /* set CD-TEXT field to value for PTI pti */
-void cdtext_set(int pti, char *value, Cdtext *cdtext);
+void cue_cdtext_set(int pti, char *value, Cdtext *cdtext);
 
 /*
  * returns appropriate string for PTI pti
  * if istrack is zero, UPC/EAN string will be returned for PTI_UPC_ISRC
  * othwise ISRC string will be returned
  */
-const char *cdtext_get_key(int pti, int istrack);
+const char *cue_cdtext_get_key(int pti, int istrack);
 
 /*
  * dump all cdtext info
  * in human readable format (for debugging)
  */
-void cdtext_dump(Cdtext *cdtext, int istrack);
+void cue_cdtext_dump(Cdtext *cdtext, int istrack);
 
 #endif

--- a/cue_parser.y
+++ b/cue_parser.y
@@ -278,7 +278,7 @@ track_flag
 	;
 
 cdtext
-	: cdtext_item STRING '\n' { cdtext_set ($1, $2, cdtext); }
+	: cdtext_item STRING '\n' { cue_cdtext_set ($1, $2, cdtext); }
 	;
 
 cdtext_item
@@ -304,7 +304,7 @@ time
 
 rem
 	: rem_item STRING '\n' { rem_set($1, $2, rem); }
-	| XXX_GENRE STRING '\n' { cdtext_set($1, $2, cdtext); }
+	| XXX_GENRE STRING '\n' { cue_cdtext_set($1, $2, cdtext); }
 	;
 
 rem_item

--- a/libcue.h
+++ b/libcue.h
@@ -125,7 +125,7 @@ CUE_EXPORT int cd_get_ntrack(const Cd *cd);
 /* CDTEXT functions */
 CUE_EXPORT Cdtext *cd_get_cdtext(const Cd *cd);
 CUE_EXPORT Cdtext *track_get_cdtext(const Track *track);
-CUE_EXPORT const char *cdtext_get(enum Pti pti, const Cdtext *cdtext);
+CUE_EXPORT const char *cue_cdtext_get(enum Pti pti, const Cdtext *cdtext);
 
 CUE_EXPORT Rem* cd_get_rem(const Cd* cd);
 CUE_EXPORT Rem* track_get_rem(const Track* track);

--- a/t/multiple_files.c
+++ b/t/multiple_files.c
@@ -47,10 +47,10 @@ static char* cue_pregap_test()
    mu_assert ("error getting CDTEXT", cdtext != NULL);
 
    const char *val;
-   val = cdtext_get (PTI_PERFORMER, cdtext);
+   val = cue_cdtext_get (PTI_PERFORMER, cdtext);
    mu_assert ("error validating CD performer", val == NULL);
 
-   val = cdtext_get (PTI_TITLE, cdtext);
+   val = cue_cdtext_get (PTI_TITLE, cdtext);
    mu_assert ("error validating CD title", val == NULL);
 
    int ival = cd_get_ntrack (cd);
@@ -68,11 +68,11 @@ static char* cue_pregap_test()
    cdtext = track_get_cdtext (track);
    mu_assert ("error getting track CDTEXT", cdtext != NULL);
 
-   val = cdtext_get (PTI_PERFORMER, cdtext);
+   val = cue_cdtext_get (PTI_PERFORMER, cdtext);
    mu_assert ("error getting track performer", val != NULL);
    mu_assert ("error validating track performer", strcmp (val, "The Specials") == 0);
 
-   val = cdtext_get (PTI_TITLE, cdtext);
+   val = cue_cdtext_get (PTI_TITLE, cdtext);
    mu_assert ("error getting track title", val != NULL);
    mu_assert ("error validating track title", strcmp (val, "Gangsters") == 0);
 
@@ -95,11 +95,11 @@ static char* cue_pregap_test()
    cdtext = track_get_cdtext (track);
    mu_assert ("error getting track CDTEXT", cdtext != NULL);
 
-   val = cdtext_get (PTI_PERFORMER, cdtext);
+   val = cue_cdtext_get (PTI_PERFORMER, cdtext);
    mu_assert ("error getting track performer", val != NULL);
    mu_assert ("error validating track performer", strcmp (val, "The Specials") == 0);
 
-   val = cdtext_get (PTI_TITLE, cdtext);
+   val = cue_cdtext_get (PTI_TITLE, cdtext);
    mu_assert ("error getting track title", val != NULL);
    mu_assert ("error validating track title", strcmp (val, "Rudi, A Message To You") == 0);
 
@@ -130,10 +130,10 @@ static char* cue_test()
    mu_assert ("error getting CDTEXT", cdtext != NULL);
 
    const char *val;
-   val = cdtext_get (PTI_PERFORMER, cdtext);
+   val = cue_cdtext_get (PTI_PERFORMER, cdtext);
    mu_assert ("error validating CD performer", val == NULL);
 
-   val = cdtext_get (PTI_TITLE, cdtext);
+   val = cue_cdtext_get (PTI_TITLE, cdtext);
    mu_assert ("error validating CD title", val == NULL);
 
    int ival = cd_get_ntrack (cd);
@@ -151,11 +151,11 @@ static char* cue_test()
    cdtext = track_get_cdtext (track);
    mu_assert ("error getting track CDTEXT", cdtext != NULL);
 
-   val = cdtext_get (PTI_PERFORMER, cdtext);
+   val = cue_cdtext_get (PTI_PERFORMER, cdtext);
    mu_assert ("error getting track performer", val != NULL);
    mu_assert ("error validating track performer", strcmp (val, "The Specials") == 0);
 
-   val = cdtext_get (PTI_TITLE, cdtext);
+   val = cue_cdtext_get (PTI_TITLE, cdtext);
    mu_assert ("error getting track title", val != NULL);
    mu_assert ("error validating track title", strcmp (val, "Gangsters") == 0);
 
@@ -178,11 +178,11 @@ static char* cue_test()
    cdtext = track_get_cdtext (track);
    mu_assert ("error getting track CDTEXT", cdtext != NULL);
 
-   val = cdtext_get (PTI_PERFORMER, cdtext);
+   val = cue_cdtext_get (PTI_PERFORMER, cdtext);
    mu_assert ("error getting track performer", val != NULL);
    mu_assert ("error validating track performer", strcmp (val, "The Specials") == 0);
 
-   val = cdtext_get (PTI_TITLE, cdtext);
+   val = cue_cdtext_get (PTI_TITLE, cdtext);
    mu_assert ("error getting track title", val != NULL);
    mu_assert ("error validating track title", strcmp (val, "Rudi, A Message To You") == 0);
 

--- a/t/noncompliant.c
+++ b/t/noncompliant.c
@@ -35,10 +35,10 @@ static char* cue_test()
    mu_assert ("error getting CDTEXT", cdtext != NULL);
 
    const char *val;
-   val = cdtext_get (PTI_PERFORMER, cdtext);
+   val = cue_cdtext_get (PTI_PERFORMER, cdtext);
    mu_assert ("error validating CD performer", val == NULL);
 
-   val = cdtext_get (PTI_TITLE, cdtext);
+   val = cue_cdtext_get (PTI_TITLE, cdtext);
    mu_assert ("error validating CD title", val == NULL);
 
    int ival = cd_get_ntrack (cd);
@@ -56,11 +56,11 @@ static char* cue_test()
    cdtext = track_get_cdtext (track);
    mu_assert ("error getting track CDTEXT", cdtext != NULL);
 
-   val = cdtext_get (PTI_PERFORMER, cdtext);
+   val = cue_cdtext_get (PTI_PERFORMER, cdtext);
    mu_assert ("error getting track performer", val != NULL);
    mu_assert ("error validating track performer", strcmp (val, "The Specials") == 0);
 
-   val = cdtext_get (PTI_TITLE, cdtext);
+   val = cue_cdtext_get (PTI_TITLE, cdtext);
    mu_assert ("error getting track title", val != NULL);
    mu_assert ("error validating track title", strcmp (val, "Gangsters") == 0);
 
@@ -83,11 +83,11 @@ static char* cue_test()
    cdtext = track_get_cdtext (track);
    mu_assert ("error getting track CDTEXT", cdtext != NULL);
 
-   val = cdtext_get (PTI_PERFORMER, cdtext);
+   val = cue_cdtext_get (PTI_PERFORMER, cdtext);
    mu_assert ("error getting track performer", val != NULL);
    mu_assert ("error validating track performer", strcmp (val, "The Specials") == 0);
 
-   val = cdtext_get (PTI_TITLE, cdtext);
+   val = cue_cdtext_get (PTI_TITLE, cdtext);
    mu_assert ("error getting track title", val != NULL);
    mu_assert ("error validating track title", strcmp (val, "Rudi, A Message To You") == 0);
 

--- a/t/single_idx_00.c
+++ b/t/single_idx_00.c
@@ -37,11 +37,11 @@ static char* cue_test()
    mu_assert ("error getting CDTEXT", cdtext != NULL);
 
    const char *val;
-   val = cdtext_get (PTI_PERFORMER, cdtext);
+   val = cue_cdtext_get (PTI_PERFORMER, cdtext);
    mu_assert ("error getting CD performer", val != NULL);
    mu_assert ("error validating CD performer", strcmp (val, "Bloc Party") == 0);
 
-   val = cdtext_get (PTI_TITLE, cdtext);
+   val = cue_cdtext_get (PTI_TITLE, cdtext);
    mu_assert ("error getting CD title", val != NULL);
    mu_assert ("error validating CD title", strcmp (val, "Silent Alarm") == 0);
 
@@ -60,11 +60,11 @@ static char* cue_test()
    cdtext = track_get_cdtext (track);
    mu_assert ("error getting track CDTEXT", cdtext != NULL);
 
-   val = cdtext_get (PTI_PERFORMER, cdtext);
+   val = cue_cdtext_get (PTI_PERFORMER, cdtext);
    mu_assert ("error getting track performer", val != NULL);
    mu_assert ("error validating track performer", strcmp (val, "Bloc Party") == 0);
 
-   val = cdtext_get (PTI_TITLE, cdtext);
+   val = cue_cdtext_get (PTI_TITLE, cdtext);
    mu_assert ("error getting track title", val != NULL);
    mu_assert ("error validating track title", strcmp (val, "Like Eating Glass") == 0);
 
@@ -91,11 +91,11 @@ static char* cue_test()
    cdtext = track_get_cdtext (track);
    mu_assert ("error getting track CDTEXT", cdtext != NULL);
 
-   val = cdtext_get (PTI_PERFORMER, cdtext);
+   val = cue_cdtext_get (PTI_PERFORMER, cdtext);
    mu_assert ("error getting track performer", val != NULL);
    mu_assert ("error validating track performer", strcmp (val, "Bloc Party") == 0);
 
-   val = cdtext_get (PTI_TITLE, cdtext);
+   val = cue_cdtext_get (PTI_TITLE, cdtext);
    mu_assert ("error getting track title", val != NULL);
    mu_assert ("error validating track title", strcmp (val, "Helicopter") == 0);
 

--- a/t/standard_cue.c
+++ b/t/standard_cue.c
@@ -38,15 +38,15 @@ static char* cue_test()
    mu_assert ("error getting CDTEXT", cdtext != NULL);
 
    const char *val;
-   val = cdtext_get (PTI_PERFORMER, cdtext);
+   val = cue_cdtext_get (PTI_PERFORMER, cdtext);
    mu_assert ("error getting CD performer", val != NULL);
    mu_assert ("error validating CD performer", strcmp (val, "My Bloody Valentine") == 0);
 
-   val = cdtext_get (PTI_TITLE, cdtext);
+   val = cue_cdtext_get (PTI_TITLE, cdtext);
    mu_assert ("error getting CD title", val != NULL);
    mu_assert ("error validating CD title", strcmp (val, "Loveless") == 0);
 
-   val = cdtext_get (PTI_GENRE, cdtext);
+   val = cue_cdtext_get (PTI_GENRE, cdtext);
    mu_assert ("error getting CD genre", val != NULL);
    mu_assert ("error validating CD genre", strcmp (val, "Alternative") == 0);
 
@@ -69,11 +69,11 @@ static char* cue_test()
    cdtext = track_get_cdtext (track);
    mu_assert ("error getting track CDTEXT", cdtext != NULL);
 
-   val = cdtext_get (PTI_PERFORMER, cdtext);
+   val = cue_cdtext_get (PTI_PERFORMER, cdtext);
    mu_assert ("error getting track performer", val != NULL);
    mu_assert ("error validating track performer", strcmp (val, "My Bloody Valentine") == 0);
 
-   val = cdtext_get (PTI_TITLE, cdtext);
+   val = cue_cdtext_get (PTI_TITLE, cdtext);
    mu_assert ("error getting track title", val != NULL);
    mu_assert ("error validating track title", strcmp (val, "Only Shallow") == 0);
 
@@ -96,11 +96,11 @@ static char* cue_test()
    cdtext = track_get_cdtext (track);
    mu_assert ("error getting track CDTEXT", cdtext != NULL);
 
-   val = cdtext_get (PTI_PERFORMER, cdtext);
+   val = cue_cdtext_get (PTI_PERFORMER, cdtext);
    mu_assert ("error getting track performer", val != NULL);
    mu_assert ("error validating track performer", strcmp (val, "My Bloody Valentine") == 0);
 
-   val = cdtext_get (PTI_TITLE, cdtext);
+   val = cue_cdtext_get (PTI_TITLE, cdtext);
    mu_assert ("error getting track title", val != NULL);
    mu_assert ("error validating track title", strcmp (val, "Loomer") == 0);
 


### PR DESCRIPTION
I use both libs in one project and get "collisions" since some functions are named equally. Maybe you will change this as well?! 

Best regards,
   Jörg