### PR TITLE
fix global oob in cue_scanner.l:49

### DIFF
--- a/cue_scanner.l
+++ b/cue_scanner.l
@@ -45,8 +45,8 @@ nonws		[^ \t\r\n]
 <NAME>{nonws}+	{
 		yylval.sval = strncpy(	yy_buffer,
 					yytext,
-					(yyleng > sizeof(yy_buffer) ? sizeof(yy_buffer) : yyleng));
-		yylval.sval[(yyleng > sizeof(yy_buffer) ? sizeof(yy_buffer) : yyleng)] = '\0';
+					(sizeof(yy_buffer) - 1 );
+		yylval.sval[sizeof(yy_buffer) - 1] = '\0';
 		BEGIN(INITIAL);
 		return STRING;
 		}


### PR DESCRIPTION
Hello,
I found  global-buffer-overflow in yylex during fuzz testing with [sydr-fuzz](https://github.com/ispras/oss-sydr-fuzz/pull/212).

Asan trace:
```
=================================================================
==8382==ERROR: AddressSanitizer: global-buffer-overflow on address 0x000000e942a0 at pc 0x000000330d2f bp 0x7ffff44957c0 sp 0x7ffff44957b8
WRITE of size 1 at 0x000000e942a0 thread T0
    #0 0x330d2e in yylex /root/libcue/build/cue_scanner.l:49:74
    #1 0x31e7bb in yyparse /root/libcue/build/cue_parser.c:1421:16
    #2 0x31c93b in cue_parse_string /root/libcue/build/cue_parser.y:371:11
    #3 0x31c93b in LLVMFuzzerTestOneInput /root/libcue/build/fuzz.c:11:12
    #4 0x317f9d in ExecuteFilesOnyByOne /AFLplusplus/utils/aflpp_driver/aflpp_driver.c:255:7
    #5 0x317da8 in LLVMFuzzerRunDriver /AFLplusplus/utils/aflpp_driver/aflpp_driver.c
    #6 0x317968 in main /AFLplusplus/utils/aflpp_driver/aflpp_driver.c:300:10
    #7 0x7fc9f3ebc082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082) (BuildId: 1878e6b475720c7c51969e69ab2d276fae6d1dee)
    #8 0x25a00d in _start (/root/libcue/build/fuzz+0x25a00d)

0x000000e942a0 is located 0 bytes to the right of global variable 'yy_buffer' defined in 'cue_scanner.l:14:6' (0xe93ea0) of size 1024
SUMMARY: AddressSanitizer: global-buffer-overflow /root/libcue/build/cue_scanner.l:49:74 in yylex
Shadow bytes around the buggy address:
  0x0000801ca800: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0000801ca810: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0000801ca820: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0000801ca830: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0000801ca840: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0000801ca850: 00 00 00 00[f9]f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0000801ca860: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0000801ca870: f9 f9 f9 f9 00 f9 f9 f9 04 f9 f9 f9 04 f9 f9 f9
  0x0000801ca880: 00 f9 f9 f9 00 00 00 00 00 00 00 00 00 00 00 00
  0x0000801ca890: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0000801ca8a0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==8382==ABORTING
```

[crash.zip](https://github.com/lipnitsk/libcue/files/12874660/crash.zip)
