### PR TITLE
Validate input ranges in time_msf_to_frame()

### DIFF
--- a/time.c
+++ b/time.c
@@ -11,6 +11,9 @@
 
 long time_msf_to_frame(int m, int s, int f)
 {
+	if (m < 0 || m > 99 || s < 0 || s >= 60 || f < 0 || f >= 75) {
+		return -1;
+	}
 	return (m * 60 + s) * 75 + f;
 }
 


### PR DESCRIPTION
Without range checks, large inputs cause signed overflow when computing times. Minutes are restricted to 0-99 because the mm field is 2 digits wide. The `time_frame_to_msf` and `time_frame_to_mmssff` functions do not properly handle "error" times of -1, but these functions are currently unused.

This was found through fuzz testing with afl under UBSan. If you're interested, here's my fuzz target:

```c
#include "cd.c"
#include "cdtext.c"
#include "rem.c"
#include "time.c"
#include "cue_parser.c"
#include "cue_scanner.c"
#include <unistd.h>

__AFL_FUZZ_INIT();

int main(void)
{
    __AFL_INIT();
    char *src = 0;
    unsigned char *buf = __AFL_FUZZ_TESTCASE_BUF;
    while (__AFL_LOOP(10000)) {
        int len = __AFL_FUZZ_TESTCASE_LEN;
        src = realloc(src, len+1);
        memcpy(src, buf, len);
        src[len] = 0;
        Cd *cd = cue_parse_string(src);
        cd_delete(cd);
    }
}
```

Quick usage example:

    $ mkdir i
    $ cp t/*.cue i/
    $ afl-gcc-fast -g3 -fsanitize=address,undefined fuzz.c
    $ afl-fuzz -ii -oo ./a.out
