### PR TITLE
Fix memory leak when attempting to add more than max tracks

### DIFF
--- a/cd.c
+++ b/cd.c
@@ -195,9 +195,11 @@ Track *cd_add_track(Cd *cd)
 	if (MAXTRACK > cd->ntrack)
 		cd->ntrack++;
 	else
+	{
 		fprintf(stderr, "too many tracks\n");
+		return cd->track[cd->ntrack - 1];
+	}
 
-	/* this will reinit last track if there were too many */
 	cd->track[cd->ntrack - 1] = track_init();
 
 	return cd->track[cd->ntrack - 1];

--- a/cue_parser.y
+++ b/cue_parser.y
@@ -193,6 +193,8 @@ new_track
 		prev_track = track;
 
 		track = cd_add_track(cd);
+		if (prev_track == track)
+			prev_track = NULL;
 		cdtext = track_get_cdtext(track);
 		rem = track_get_rem(track);
 


### PR DESCRIPTION
This fixes memory leak in https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=63325
It is a bit tricky to fix because if I delete the track before it is rewritten in `track_init` it crashes in `cue_parser.y` because `prev_track` holds the pointer to the deleted track. If I do not delete the track, but return `NULL` instead of creating a new track - it crashes because too many things assume the track is not null. The solution to return the pointer to the old track and reset `prev_track` if it the same pointer seems to work the best.