### PR TITLE
Delete an unnecessary #include directive

### DIFF
--- a/libcue.h
+++ b/libcue.h
@@ -5,9 +5,6 @@
 
 #ifndef LIBCUE_H
 #define LIBCUE_H
-
-#include <stdio.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
:eyes: [The preprocessing directive “`#include <stdio.h>`” was used in the header file for this software library so far](https://github.com/lipnitsk/libcue/blob/7176a1faccecbfe2d4cca2f776177439ca49cad2/libcue.h#L9 "Update candidate") despite of the implementation detail that corresponding symbols were not applied here.
:thought_balloon: Thus delete such a redundant file inclusion specification.