### PR TITLE
Delete unnecessary checks before some function calls

### DIFF
--- a/cd.c
+++ b/cd.c
@@ -154,17 +154,13 @@ enum DiscMode cd_get_mode(const Cd *cd)
 
 void cd_set_catalog(Cd *cd, char *catalog)
 {
-	if (cd->catalog)
-		free(cd->catalog);
-
+	free(cd->catalog);
 	cd->catalog = strdup(catalog);
 }
 
 void cd_set_cdtextfile(Cd *cd, char *cdtextfile)
 {
-	if (cd->cdtextfile)
-		free(cd->cdtextfile);
-
+	free(cd->cdtextfile);
 	cd->cdtextfile = strdup(cdtextfile);
 }
 
@@ -224,9 +220,7 @@ Track *cd_get_track(const Cd *cd, int i)
 
 void track_set_filename(Track *track, char *filename)
 {
-	if (track->file.name)
-		free(track->file.name);
-
+	free(track->file.name);
 	track->file.name = strdup(filename);
 }
 
@@ -311,9 +305,7 @@ long track_get_zero_post(const Track *track)
 }
 void track_set_isrc(Track *track, char *isrc)
 {
-	if (track->isrc)
-		free(track->isrc);
-
+	free(track->isrc);
 	track->isrc = strdup(isrc);
 }
 

--- a/cue_parser.y
+++ b/cue_parser.y
@@ -353,7 +353,7 @@ Cd *cue_parse_file(FILE *fp)
 	else
 	{
 		ret_cd = NULL;
-		if (cd) cd_delete(cd);
+		cd_delete(cd);
 	}
 
 	yy_delete_buffer(buffer);
@@ -374,7 +374,7 @@ Cd *cue_parse_string(const char* string)
 	else
 	{
 		ret_cd = NULL;
-		if (cd) cd_delete(cd);
+		cd_delete(cd);
 	}
 
 	yy_delete_buffer(buffer);


### PR DESCRIPTION
- [The function “free”](https://stackoverflow.com/questions/18775608/free-a-null-pointer-anyway-or-check-first "Free a null pointer anyway or check first?") is documented in the way that no action shall occur for a passed null pointer.
  Redundant safety checks can be avoided.
- [The function “cd_delete” of this software library tolerates also the passing of null pointers](https://github.com/lipnitsk/libcue/blob/7176a1faccecbfe2d4cca2f776177439ca49cad2/cd.c#L83 "Implementation of cd_delete()").
  It is therefore not needed that a function caller repeats a corresponding check.