### PR TITLE
Fix yylineno integer overflow

### DIFF
--- a/cue_parser.y
+++ b/cue_parser.y
@@ -349,6 +349,7 @@ Cd *cue_parse_file(FILE *fp)
 
 	Cd *ret_cd = NULL;
 
+	yylineno = 1;
 	if (0 == yyparse()) ret_cd = cd;
 	else
 	{
@@ -370,6 +371,7 @@ Cd *cue_parse_string(const char* string)
 
 	Cd *ret_cd = NULL;
 
+	yylineno = 1;
 	if (0 == yyparse()) ret_cd = cd;
 	else
 	{


### PR DESCRIPTION
This fixes int overflow in https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=63758