### PR TITLE
Allow unlimited newlines at EOF

### DIFF
--- a/cue_parser.y
+++ b/cue_parser.y
@@ -130,7 +130,7 @@ Cd *cue_parse_string(const char*);
 %%
 
 cuefile
-	: new_cd global_statements track_list
+	: new_cd global_statements track_list end_cd
 	;
 
 new_cd
@@ -315,6 +315,11 @@ rem_item
 	| REPLAYGAIN_ALBUM_PEAK
 	| REPLAYGAIN_TRACK_GAIN
 	| REPLAYGAIN_TRACK_PEAK
+	;
+
+end_cd
+	: /* empty */
+	| '\n' end_cd
 	;
 %%
 

--- a/t/noncompliant.c
+++ b/t/noncompliant.c
@@ -21,7 +21,7 @@ static char cue[] =
                      "PERFORMER \"The Specials\"\n"
                      "INDEX 00 02:47:74\n"
                "FILE \"The Specials - Singles - 02 - Rudi, A Message To You.flac\" FLAC\n"
-                     "INDEX 01 00:00:00\n";
+                     "INDEX 01 00:00:00\n\n\n\n\n\n";
 
 static char* cue_test()
 {

--- a/t/single_idx_00.c
+++ b/t/single_idx_00.c
@@ -23,7 +23,7 @@ static char cue[] =
       "TITLE \"Helicopter\"\n"
       "PERFORMER \"Bloc Party\"\n"
       "INDEX 00 07:42:69\n"
-      "INDEX 01 07:44:69\n";
+      "INDEX 01 07:44:69";
 
 static char* cue_test()
 {


### PR DESCRIPTION
Add a new parser rule that allows unlimited newlines at end-of-file.  Fixes #52 - also modified a couple test cases for newline compliance (one now has no newline at end, another has 5)