### PR TITLE
Change function signature of rem_get to use enum

### DIFF
--- a/libcue.h
+++ b/libcue.h
@@ -133,7 +133,7 @@ CUE_EXPORT Rem* track_get_rem(const Track* track);
  * return pointer to value for rem comment
  * @param unsigned int: enum of rem comment
  */
-CUE_EXPORT const char* rem_get(unsigned int, Rem*);
+CUE_EXPORT const char* rem_get(enum RemType cmt, const Rem *rem);
 
 /* Track functions */
 CUE_EXPORT Track *cd_get_track(const Cd *cd, int i);

--- a/rem.c
+++ b/rem.c
@@ -108,7 +108,7 @@ rem_set(	unsigned int cmt,
 
 const char*
 rem_get(	RemType cmt,
-		Rem* rem)
+		const Rem* rem)
 {
 	if (rem == NULL)
 		return NULL;


### PR DESCRIPTION
This makes it align with the `cdtext_get()` function.