### PR TITLE
Change null pointer check order in cd_get_track

### DIFF
--- a/cd.c
+++ b/cd.c
@@ -212,7 +212,7 @@ int cd_get_ntrack(const Cd *cd)
 
 Track *cd_get_track(const Cd *cd, int i)
 {
-	if ((0 < i) && (i <= cd->ntrack) && (cd != NULL))
+	if ((0 < i) && (cd != NULL) && (i <= cd->ntrack))
 		return cd->track[i - 1];
 	else
 		return NULL;


### PR DESCRIPTION
The check of whether `cd` is NULL should come before accessing `cd->ntrack`, otherwise a program will still crash with a null pointer.