### PR TITLE
Improve compatibility on windows platform

### DIFF
--- a/cue_scanner.l
+++ b/cue_scanner.l
@@ -24,6 +24,7 @@ nonws		[^ \t\r\n]
 %option noinput
 %option nounput
 %option caseless
+%option never-interactive
 
 %s NAME
 %x REM

--- a/libcue.h
+++ b/libcue.h
@@ -12,7 +12,11 @@
 extern "C" {
 #endif
 
-#define CUE_EXPORT __attribute__((visibility("default")))
+#ifdef _MSC_VER
+	#define CUE_EXPORT __declspec(dllexport)
+#else
+	#define CUE_EXPORT __attribute__((visibility("default")))
+#endif
 
 /*
  * disc modes


### PR DESCRIPTION
- gcc's `__attribute__()` extension is not supported by msvc. This pr replaces it with `__declspec(dllexport)` keyword to mark exported functions when using msvc.
- Flex includes unistd.h to detect interactive inputs, which is not available on windows platform. Since CUE sheets are not handled as interactive contents, this pr avoid the use of unistd.h by setting flex's `never-interactive` option to ensure compatibility on windows platform.
