### PR TITLE
Parse "REM DISCID" and "REM COMPOSER" lines

### DIFF
--- a/cue_parser.y
+++ b/cue_parser.y
@@ -123,6 +123,8 @@ Cd *cue_parse_string(const char*);
 %type <ival> rem_item
 %token <ival> DATE
 %token <ival> XXX_GENRE /* parsed in REM but stored in CD-TEXT */
+%token <ival> XXX_DISCID
+%token <ival> XXX_COMPOSER
 %token <ival> REPLAYGAIN_ALBUM_GAIN
 %token <ival> REPLAYGAIN_ALBUM_PEAK
 %token <ival> REPLAYGAIN_TRACK_GAIN
@@ -310,6 +312,8 @@ time
 rem
 	: rem_item STRING '\n' { rem_set($1, $2, rem); }
 	| XXX_GENRE STRING '\n' { cdtext_set($1, $2, cdtext); }
+	| XXX_DISCID STRING '\n' { cdtext_set($1, $2, cdtext); }
+	| XXX_COMPOSER STRING '\n' { cdtext_set($1, $2, cdtext); }
 	;
 
 rem_item

--- a/cue_scanner.l
+++ b/cue_scanner.l
@@ -103,6 +103,8 @@ REM		{ BEGIN(REM); /* exclusive rules for special exceptions */ }
 
 <REM>DATE			{ BEGIN(NAME); yylval.ival = REM_DATE; return DATE; }
 <REM>GENRE			{ BEGIN(NAME); yylval.ival = PTI_GENRE; return XXX_GENRE; }
+<REM>DISCID			{ BEGIN(NAME); yylval.ival = PTI_DISC_ID; return XXX_DISCID; }
+<REM>COMPOSER			{ BEGIN(NAME); yylval.ival = PTI_COMPOSER; return XXX_COMPOSER; }
 <REM>REPLAYGAIN_ALBUM_GAIN 	{ BEGIN(RPG); yylval.ival = REM_REPLAYGAIN_ALBUM_GAIN;
 							return REPLAYGAIN_ALBUM_GAIN; }
 <REM>REPLAYGAIN_ALBUM_PEAK	{ BEGIN(RPG); yylval.ival = REM_REPLAYGAIN_ALBUM_PEAK;

--- a/t/standard_cue.c
+++ b/t/standard_cue.c
@@ -64,6 +64,10 @@ static char* cue_test()
    mu_assert ("error getting CD total discs", val != NULL);
    mu_assert ("error validating CD total discs", strcmp (val, "2") == 0);
 
+   val = cdtext_get (PTI_DISC_ID, cdtext);
+   mu_assert ("error getting CD disc id", val != NULL);
+   mu_assert ("error validating CD disc id", strcmp (val, "860B640B") == 0);
+
    val = rem_get (REM_COMMENT, rem);
    mu_assert ("error getting CD comment", val != NULL);
    mu_assert ("error validating CD comment", strcmp (val, "ExactAudioCopy v0.95b4") == 0);


### PR DESCRIPTION
Some widely used software (like ExactAudioCopy) writes DISC_ID and COMPOSER to REM fields (as in https://github.com/lipnitsk/libcue/blob/c901e16098dd075dc6862197862cc54bdf086213/t/standard_cue.c#L15 ).

This pr uses the fix similiar to #4 to make libcue also parse "REM DISCID" and "REM COMPOSER" fields and still store them in cdtext like DISC_ID and COMPOSER.

Fixes #58 
