### PR TITLE
Usability improvements

### DIFF
--- a/cue_parser.y
+++ b/cue_parser.y
@@ -10,7 +10,7 @@
 #include <string.h>
 
 #include "cd.h"
-#include "time.h"
+#include "cue_time.h"
 
 #ifdef YY_BUF_SIZE
 #undef YY_BUF_SIZE

--- a/cue_time.h
+++ b/cue_time.h
@@ -1,12 +1,12 @@
 /*
- * time.h -- time declarations
+ * cue_time.h -- time declarations
  *
  * Copyright (C) 2004, 2005, 2006, 2007 Svend Sorensen
  * For license terms, see the file COPYING in this distribution.
  */
 
-#ifndef TIME_H
-#define TIME_H
+#ifndef CUE_TIME_H
+#define CUE_TIME_H
 
 long time_msf_to_frame(int m, int s, int f);
 void time_frame_to_msf(long frame, int *m, int *s, int *f);

--- a/libcue.h
+++ b/libcue.h
@@ -18,6 +18,9 @@ extern "C" {
 	#define CUE_EXPORT __attribute__((visibility("default")))
 #endif
 
+/* Frames per second */
+#define CUE_FPS (75)
+
 /*
  * disc modes
  * DATA FORM OF MAIN DATA (5.29.2.8)

--- a/t/multiple_files.c
+++ b/t/multiple_files.c
@@ -6,9 +6,7 @@
 
 int tests_run;
 
-/* Frames per second */
-#define FPS (75)
-#define MSF_TO_F(m,s,f) ((f) + ((m)*60 + (s))*FPS)
+#define MSF_TO_F(m,s,f) ((f) + ((m)*60 + (s))*CUE_FPS)
 
 static char cue[] = "FILE \"The Specials - Singles - 01 - Gangsters.wav\" WAVE\n"
                         "TRACK 01 AUDIO\n"

--- a/t/noncompliant.c
+++ b/t/noncompliant.c
@@ -6,9 +6,7 @@
 
 int tests_run;
 
-/* Frames per second */
-#define FPS (75)
-#define MSF_TO_F(m,s,f) ((f) + ((m)*60 + (s))*FPS)
+#define MSF_TO_F(m,s,f) ((f) + ((m)*60 + (s))*CUE_FPS)
 
 static char cue[] = 
                "FILE \"The Specials - Singles - 01 - Gangsters.flac\" FLAC\n"

--- a/t/single_idx_00.c
+++ b/t/single_idx_00.c
@@ -6,9 +6,7 @@
 
 int tests_run;
 
-/* Frames per second */
-#define FPS (75)
-#define MSF_TO_F(m,s,f) ((f) + ((m)*60 + (s))*FPS)
+#define MSF_TO_F(m,s,f) ((f) + ((m)*60 + (s))*CUE_FPS)
 
 static char cue[] =
 "PERFORMER \"Bloc Party\"\n"

--- a/t/standard_cue.c
+++ b/t/standard_cue.c
@@ -6,9 +6,7 @@
 
 int tests_run;
 
-/* Frames per second */
-#define FPS (75)
-#define MSF_TO_F(m,s,f) ((f) + ((m)*60 + (s))*FPS)
+#define MSF_TO_F(m,s,f) ((f) + ((m)*60 + (s))*CUE_FPS)
 
 static char cue[] =   "REM GENRE Alternative\n"
                       "REM DATE 1991\n"

--- a/time.c
+++ b/time.c
@@ -10,19 +10,20 @@
 #include <string.h>
 
 #include "cue_time.h"
+#include "libcue.h"
 
 long time_msf_to_frame(int m, int s, int f)
 {
-	if (m < 0 || m > 99 || s < 0 || s >= 60 || f < 0 || f >= 75) {
+	if (m < 0 || m > 99 || s < 0 || s >= 60 || f < 0 || f >= CUE_FPS) {
 		return -1;
 	}
-	return (m * 60 + s) * 75 + f;
+	return (m * 60 + s) * CUE_FPS + f;
 }
 
 void time_frame_to_msf(long frame, int *m, int *s, int *f)
 {
-	*f = frame % 75;           /* 0 <= frames <= 74 */
-	frame /= 75;
+	*f = frame % CUE_FPS;           /* 0 <= frames <= 74 */
+	frame /= CUE_FPS;
 	*s = frame % 60;          /* 0 <= seconds <= 59 */
 	frame /= 60;
 	*m = frame;               /* 0 <= minutes */
@@ -34,7 +35,7 @@ char *time_frame_to_mmssff(long f)
 	static char msf[9];
 	int minutes, seconds, frames;
 
-	if (f < 0 || f >= 75 * 60 * 100) {
+	if (f < 0 || f >= CUE_FPS * 60 * 100) {
 		strcpy(msf, "00:00:00");
 		return msf;
 	}

--- a/time.c
+++ b/time.c
@@ -5,10 +5,11 @@
  * For license terms, see the file COPYING in this distribution.
  */
 
-#include "time.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include "cue_time.h"
 
 long time_msf_to_frame(int m, int s, int f)
 {


### PR DESCRIPTION
- time.h has been renamed to cue_time.h in order to avoid conflicts in projects which consume both libcue and the libc time.
- the FPS macro is now CUE_FPS to be used by both time.c and external consumers